### PR TITLE
Ubuntu 20.04, python 3, pybombs 2.3.4 version bumps

### DIFF
--- a/pybombs-commondeps/Dockerfile
+++ b/pybombs-commondeps/Dockerfile
@@ -13,12 +13,19 @@ ARG TZ=Etc/UTC
 RUN ln -fs /usr/share/zoneinfo/$TZ /etc/localtime
 
 RUN pybombs config makewidth $makewidth
+
+# installing qwt5 will fail due to lack of X11 headers.
+# Temp fix until this is solved in the pybombs recipe (see gnuradio/gr-recipes#197):
+RUN apt-get update && apt-get install -y \
+	libqwt-qt5-dev \
+	python3-pyqt5.qwt
+
 # Now list all the dependencies that we want to ship in this container:
 # (I use separate RUN commands so I can maybe have an easier time building)
 RUN pybombs install boost doxygen
 RUN pybombs install libtool autoconf automake
-RUN pybombs install qwt5 sip lxml
-RUN pybombs install pygtk pycairo pyqwt5 python-requests six mako numpy
+RUN pybombs install sip lxml
+RUN pybombs install pygtk pycairo python-requests six mako numpy
 RUN pybombs install gsl fftw
 RUN pybombs install zeromq python-zmq
 RUN pybombs install libusb alsa

--- a/pybombs-commondeps/Dockerfile
+++ b/pybombs-commondeps/Dockerfile
@@ -14,17 +14,12 @@ RUN ln -fs /usr/share/zoneinfo/$TZ /etc/localtime
 
 RUN pybombs config makewidth $makewidth
 
-# installing qwt5 will fail due to lack of X11 headers.
-# Temp fix until this is solved in the pybombs recipe (see gnuradio/gr-recipes#197):
-RUN apt-get update && apt-get install -y \
-	libqwt-qt5-dev \
-	python3-pyqt5.qwt
-
 # Now list all the dependencies that we want to ship in this container:
 # (I use separate RUN commands so I can maybe have an easier time building)
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq
 RUN pybombs install boost doxygen
 RUN pybombs install libtool autoconf automake
-RUN pybombs install sip lxml
+RUN pybombs install qwt6 sip lxml
 RUN pybombs install pygtk pycairo python-requests six mako numpy
 RUN pybombs install gsl fftw
 RUN pybombs install zeromq python-zmq

--- a/pybombs-commondeps/Dockerfile
+++ b/pybombs-commondeps/Dockerfile
@@ -1,8 +1,16 @@
-FROM pybombs/pybombs-prefix:2.3.3
+FROM pybombs/pybombs-prefix:2.3.4
 LABEL maintainer=martin@gnuradio.org
 
 # This allows setting the makewidth temporarily to a higher value
 ARG makewidth=2
+
+# Temporarily set frontend to noninteractive to avoid warnings
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Ubuntu 20.04 gets stuck on tzdata configuration during build.
+# Providing a default timezone that can be overridden using build-args:
+ARG TZ=Etc/UTC
+RUN ln -fs /usr/share/zoneinfo/$TZ /etc/localtime
 
 RUN pybombs config makewidth $makewidth
 # Now list all the dependencies that we want to ship in this container:

--- a/pybombs-commondeps/README.md
+++ b/pybombs-commondeps/README.md
@@ -5,3 +5,22 @@ and will initialize an empty prefix. Furthermore, it will contain the most
 common dependencies for most GNU Radio-related recipes. Calling `pybombs
 install` will not only work without issues, it'll also be pretty fast as it
 doesn't need install lots of dependencies.
+
+## Note on tzdata configuration
+
+This container configures the timezone to `Etc/UTC` by default. You can change
+this behavior either at build-time or at run-time.
+
+### Build-time 
+
+To build this container with sensible tzdata for your region, simply provide a
+`TZ` argument to the build command:
+
+    docker build --build-args TZ=America/New_York -t pybombs-commondeps .
+
+### Run-time
+
+At run-time, reconfigure the timezone to a sensible value for your region by
+running
+
+    dpkg-reconfigure tzdata

--- a/pybombs-minimal/Dockerfile
+++ b/pybombs-minimal/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer=martin@gnuradio.org
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -q
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip python-apt apt-utils
-RUN pip install --upgrade pip
-RUN pip install pybombs
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip python3-apt apt-utils
+RUN pip3 install --upgrade pip
+RUN pip3 install pybombs
 RUN pybombs auto-config
 RUN pybombs config makewidth 2

--- a/pybombs-prefix/Dockerfile
+++ b/pybombs-prefix/Dockerfile
@@ -1,4 +1,4 @@
-FROM pybombs/pybombs-minimal:2.3.3
+FROM pybombs/pybombs-minimal:2.3.4
 LABEL maintainer=martin@gnuradio.org
 # Create a prefix in /pybombs
 RUN pybombs prefix init /pybombs -a default


### PR DESCRIPTION
Not sure if this repo is EOL or if it should be kept up to speed, I took the liberty of bumping this to

- Ubuntu 20.04
- Python 3
- PyBOMBS 2.3.4

and made some minimal changes to the Dockerfiles where I felt it streamlined things (some of the changes are direct results of the Ubuntu bump, as it wouldn't build on 20.04 otherwise).

~~This PR is currently a **work in progress and should not be merged as-is**, as `pybombs-commondeps` **fails to build correctly**.~~

~~As far as I can tell, this is due to certain recipes installed in the commondeps Dockerfile having issues with Ubuntu 20.04 (seems related to [this discussion](https://github.com/gnuradio/pybombs/issues/573)). To me it looks like the root cause for these issues lies in (at least) the `qwt5` PyBOMBS recipe + its dependencies / related packages, which seem to refer to packages that don't work well with Ubuntu 20.04.~~

~~As I am inexperienced with recipe development, I wanted to post this anyways, maybe somoeone can pick this up on the recipe side of things to make things work?~~

~~The `pybombs-minimal` and `pybombs-prefix` images build fine on my end.~~

**This builds correctly now**. I was able to isolate the problems to the `qwt5` and `pyqwt5` packages, and implemented a workaround for those packages until the recipes are fixed (see gnuradio/gr-recipes#197).