### PR TITLE
Build script & some reorg

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,30 +1,16 @@
 set -e
 
-# Build minimal image
-echo "Building minimal image"
-cd pybombs-minimal
-docker build -t pybombs/pybombs-minimal:latest .
-pbversion=`docker run --rm -it pybombs/pybombs-minimal:latest pybombs --version | tr -d '\r'`
-docker tag pybombs/pybombs-minimal:latest pybombs/pybombs-minimal:$pbversion
-echo "Successfully built pybombs/pybombs-minimal (tagged latest and $pbversion)"
-echo ""
+images="minimal prefix commondeps"
+for img in $images; do
+    echo -e "\e[1;36mBuilding pybombs-$img ...\e[0m"
+    cd pybombs-$img
+    docker build -t pybombs/pybombs-$img:latest .
+    pbversion=`docker run --rm -it pybombs/pybombs-$img:latest pybombs --version | tr -d '\r'`
+    docker tag pybombs/pybombs-$img:latest pybombs/pybombs-$img:$pbversion
+    echo -e "\e[1;36mSuccessfully built pybombs/pybombs-$img (tagged latest and $pbversion).\e[0m"
+    cd ..
+    echo ""
+done
 
-# Build prefix image
-echo "Building prefix image"
-cd ../pybombs-prefix
-docker build -t pybombs/pybombs-prefix:latest .
-docker tag pybombs/pybombs-prefix:latest pybombs/pybombs-prefix:$pbversion
-echo "Successfully built pybombs/pybombs-prefix (tagged latest and $pbversion)"
-echo ""
-
-# Build commondeps image
-echo "Building commondeps image"
-cd ../pybombs-commondeps
-numthreads=`nproc || 2`
-docker build --build-arg makewidth=$numthreads -t pybombs/pybombs-commondeps:latest .
-docker tag pybombs/pybombs-commondeps:latest pybombs/pybombs-commondeps:$pbversion
-echo "Successfully built pybombs/pybombs-commondeps (tagged latest and $pbversion)"
-echo ""
-
-echo "Created the following images:"
+echo -e "\e[1;36mCreated the following images:\e[0m"
 docker images | grep pybombs/pybombs

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,30 @@
+set -e
+
+# Build minimal image
+echo "Building minimal image"
+cd pybombs-minimal
+docker build -t pybombs/pybombs-minimal:latest .
+pbversion=`docker run --rm -it pybombs/pybombs-minimal:latest pybombs --version | tr -d '\r'`
+docker tag pybombs/pybombs-minimal:latest pybombs/pybombs-minimal:$pbversion
+echo "Successfully built pybombs/pybombs-minimal (tagged latest and $pbversion)"
+echo ""
+
+# Build prefix image
+echo "Building prefix image"
+cd ../pybombs-prefix
+docker build -t pybombs/pybombs-prefix:latest .
+docker tag pybombs/pybombs-prefix:latest pybombs/pybombs-prefix:$pbversion
+echo "Successfully built pybombs/pybombs-prefix (tagged latest and $pbversion)"
+echo ""
+
+# Build commondeps image
+echo "Building commondeps image"
+cd ../pybombs-commondeps
+numthreads=`nproc || 2`
+docker build --build-arg makewidth=$numthreads -t pybombs/pybombs-commondeps:latest .
+docker tag pybombs/pybombs-commondeps:latest pybombs/pybombs-commondeps:$pbversion
+echo "Successfully built pybombs/pybombs-commondeps (tagged latest and $pbversion)"
+echo ""
+
+echo "Created the following images:"
+docker images | grep pybombs/pybombs

--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,85 @@
+#!/bin/bash
 set -e
+set -o pipefail
 
-images="minimal prefix commondeps"
-for img in $images; do
-    echo -e "\e[1;36mBuilding pybombs-$img ...\e[0m"
-    cd pybombs-$img
-    docker build -t pybombs/pybombs-$img:latest .
-    pbversion=`docker run --rm -it pybombs/pybombs-$img:latest pybombs --version | tr -d '\r'`
-    docker tag pybombs/pybombs-$img:latest pybombs/pybombs-$img:$pbversion
-    echo -e "\e[1;36mSuccessfully built pybombs/pybombs-$img (tagged latest and $pbversion).\e[0m"
-    cd ..
-    echo ""
-done
+cmd=${1-usage}
+org=${org-pybombs}
+default_images="pybombs-minimal pybombs-prefix pybombs-commondeps"
 
-echo -e "\e[1;36mCreated the following images:\e[0m"
-docker images | grep pybombs/pybombs
+case $cmd in
+    build )
+        images=${2-$default_images}
+        for img in $images; do
+                echo -e "\e[1;36mBuilding $org/$img:latest ...\e[0m"
+                cd $img
+               docker build --build-arg makewidth=`nproc` -t $org/$img:latest .
+                pbversion=`docker run --rm -it $org/$img:latest pybombs --version | tr -d '\r'`
+                docker tag $org/$img:latest $org/$img:$pbversion
+                echo -e "\e[1;36mSuccessfully built pybombs/pybombs-$img (tagged latest and $pbversion).\e[0m"
+                cd ..
+                echo ""
+        done
+        echo -e "\e[1;36mCreated the following images:\e[0m"
+        docker images | grep $org/
+        ;;
+    push )
+        img=${2-_}
+        tags=${3-_}
+        if [[ $img = "_" ]]; then
+            echo "${0} ${1} requires an image name passed as an argument."
+            exit 1
+        fi
+        if [[ $tags = "_" ]]; then
+            tags=`docker images --format "{{.Repository}}:{{.Tag}}" | grep "$org/$img" | cut -d':' -f2`
+        fi
+        for tag in $tags; do
+                echo -e "\e[1;36mPushing $org/$img:$tag ...\e[0m"
+            docker push "$org/$img:$tag"
+        done
+        ;;
+    update )
+        images=${2-$default_images}
+        echo -e "\e[1;36mBuild $images ...\e[0m"
+        for img in $images; do
+            ${0} build $img
+        done
+        echo -e "\e[1;36mPush $images ...\e[0m"
+        for img in $images; do
+            ${0} push $img
+        done
+        ;;
+    clean )
+        echo -e "\e[1;36mCleaning up ...\e[0m"
+        rmi=`docker images --format "{{.Repository}}:{{.Tag}}" | grep "$org/"`
+        for r in $rmi; do
+            docker rmi $r && echo -e "\e[1;36mRemoved $r.\e[0m"
+        done
+        echo -e "\e[1;36mPrune images?\e[0m"
+        read -p "y / n " yn
+        case $yn in
+            [Yy]* ) yes | docker image prune;;
+            [Nn]* ) exit;;
+            * ) echo "Please answer yes or no.";;
+        esac
+        ;;
+    * )
+        cat <<USAGE
+Usage:
+./build.sh <command> [...]
+
+Commands:
+    - build [<image>]       Builds <image>, or all images if no argument is 
+                            provided.
+    - push <image> [<tag>]  Pushes <image>:<tag>, or all available tags if no
+                            argument is provided.
+    - update [<image>]      Builds and pushes <image> with all current tags,
+                            or all images if no <image> is provided.
+    - clean                 Remove local ${org}/* images.
+    - usage                 Show this message.
+
+USAGE
+
+esac
+
+exit
+

--- a/build.sh
+++ b/build.sh
@@ -9,10 +9,11 @@ default_images="pybombs-minimal pybombs-prefix pybombs-commondeps"
 case $cmd in
     build )
         images=${2-$default_images}
+        moreargs="${@:3}"
         for img in $images; do
                 echo -e "\e[1;36mBuilding $org/$img:latest ...\e[0m"
                 cd $img
-               docker build --build-arg makewidth=`nproc` -t $org/$img:latest .
+                docker build --build-arg makewidth=`nproc` $moreargs -t $org/$img:latest .
                 pbversion=`docker run --rm -it $org/$img:latest pybombs --version | tr -d '\r'`
                 docker tag $org/$img:latest $org/$img:$pbversion
                 echo -e "\e[1;36mSuccessfully built pybombs/pybombs-$img (tagged latest and $pbversion).\e[0m"
@@ -41,7 +42,7 @@ case $cmd in
         images=${2-$default_images}
         echo -e "\e[1;36mBuild $images ...\e[0m"
         for img in $images; do
-            ${0} build $img
+            ${0} build $img --no-cache
         done
         echo -e "\e[1;36mPush $images ...\e[0m"
         for img in $images; do

--- a/pybombs-commondeps/Dockerfile
+++ b/pybombs-commondeps/Dockerfile
@@ -7,11 +7,6 @@ ARG makewidth=2
 # Temporarily set frontend to noninteractive to avoid warnings
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Ubuntu 20.04 gets stuck on tzdata configuration during build.
-# Providing a default timezone that can be overridden using build-args:
-ARG TZ=Etc/UTC
-RUN ln -fs /usr/share/zoneinfo/$TZ /etc/localtime
-
 RUN pybombs config makewidth $makewidth
 
 # Now list all the dependencies that we want to ship in this container:

--- a/pybombs-commondeps/README.md
+++ b/pybombs-commondeps/README.md
@@ -6,21 +6,3 @@ common dependencies for most GNU Radio-related recipes. Calling `pybombs
 install` will not only work without issues, it'll also be pretty fast as it
 doesn't need install lots of dependencies.
 
-## Note on tzdata configuration
-
-This container configures the timezone to `Etc/UTC` by default. You can change
-this behavior either at build-time or at run-time.
-
-### Build-time 
-
-To build this container with sensible tzdata for your region, simply provide a
-`TZ` argument to the build command:
-
-    docker build --build-args TZ=America/New_York -t pybombs-commondeps .
-
-### Run-time
-
-At run-time, reconfigure the timezone to a sensible value for your region by
-running
-
-    dpkg-reconfigure tzdata

--- a/pybombs-minimal/Dockerfile
+++ b/pybombs-minimal/Dockerfile
@@ -1,9 +1,15 @@
 FROM ubuntu:20.04
 LABEL maintainer=martin@gnuradio.org
 
+# Ubuntu 20.04 gets stuck on tzdata configuration during build.
+# Providing a default timezone that can be overridden using build-args:
+ARG TZ=Etc/UTC
+RUN ln -fs /usr/share/zoneinfo/$TZ /etc/localtime
+
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -q
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip python3-apt apt-utils
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip python3-apt apt-utils tzdata
 RUN pip3 install --upgrade pip
 RUN pip3 install pybombs
 RUN pybombs auto-config
 RUN pybombs config makewidth 2
+

--- a/pybombs-minimal/Dockerfile
+++ b/pybombs-minimal/Dockerfile
@@ -7,9 +7,9 @@ ARG TZ=Etc/UTC
 RUN ln -fs /usr/share/zoneinfo/$TZ /etc/localtime
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -q
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip python3-apt apt-utils tzdata
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git python3-pip python3-apt apt-utils tzdata
 RUN pip3 install --upgrade pip
-RUN pip3 install pybombs
+RUN git clone https://github.com/gnuradio/pybombs.git && cd pybombs && python3 setup.py install
 RUN pybombs auto-config
 RUN pybombs config makewidth 2
 

--- a/pybombs-minimal/README.md
+++ b/pybombs-minimal/README.md
@@ -3,3 +3,21 @@
 This container will install Python and pip, and then use the latter to install
 the latest version of PyBOMBS.
 
+## Note on tzdata configuration
+
+This container configures the timezone to `Etc/UTC` by default. You can change
+this behavior either at build-time or at run-time.
+
+### Build-time
+
+To build this container with sensible tzdata for your region, simply provide a
+`TZ` argument to the build command:
+
+    docker build --build-args TZ=America/New_York -t pybombs-commondeps .
+
+### Run-time
+
+At run-time, reconfigure the timezone to a sensible value for your region by
+running
+
+    dpkg-reconfigure tzdata


### PR DESCRIPTION
1. Added a build script that builds all images sequentially and automatically tags them appropriately. This script can be extended to automatically push built images to DockerHub ~depending on issue #4~ **fixes #4**.
2. Moved tzdata to the `pybombs-minimal` image, because there are applications in which one might want to use intermediate images directly (such as the autotest script in gnuradio/gr-recipes#200, but I have other ideas as well). In these cases, a container may lock up requesting timezone configuration which will get it stuck if it's run non-interactively.